### PR TITLE
Refactors invited wishlist page to use state insteaf of inline DB call

### DIFF
--- a/src/features/lib/authentication/reducers.js
+++ b/src/features/lib/authentication/reducers.js
@@ -98,6 +98,8 @@ const userReducer = (state = initialState, action) => {
     case SEARCH_FOR_USERS_WITH_NAME_SUCCESS:
       nextState.searchResults = searchResults;
       return nextState;
+    default:
+      return nextState;
   }
   return nextState;
 };

--- a/src/features/pages/invitedWishlistPage/InvitedWishlistPage.js
+++ b/src/features/pages/invitedWishlistPage/InvitedWishlistPage.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { connect } from "react-redux";
 
 import PageHeader from "../../components/pageHeader";
 import WishlistItem from "./components/wishlistItem";
@@ -22,22 +23,13 @@ class InvitedWishlistPage extends React.Component {
     };
   }
 
-  getAllWishlistItems() {
-    const { uid } = this.state;
-    firebase
-      .firestore()
-      .collection("Wishlists")
-      .doc(uid)
-      .get()
-      .then(doc => {
-        if (doc.data()) {
-          this.setState({ items: doc.data().items, name: doc.data().title });
-        }
-      });
-  }
-
   componentDidMount() {
-    this.getAllWishlistItems();
+    const { uid } = this.state;
+    //this.getAllWishlistItems();
+    let wishlist = this.props.wishlists.find(function(list) {
+      return list.uid === uid;
+    });
+    this.setState({ items: wishlist.items, name: wishlist.title });
   }
 
   toggleChatWindow() {
@@ -75,4 +67,14 @@ class InvitedWishlistPage extends React.Component {
   }
 }
 
-export default InvitedWishlistPage;
+const mapStateToProps = state => {
+  return state => ({
+    user: state.auth,
+    wishlists: state.wishlist.wishlists
+  });
+};
+
+export default connect(
+  mapStateToProps,
+  null
+)(InvitedWishlistPage);


### PR DESCRIPTION
Blev bara en commit då refaktoreringen jag tänkt göra visade sig vara på tok för major. Gör bara så att invited wishlist page inte populeras via ett inline DB call.